### PR TITLE
Add getter and setter examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/config/mapping.json
+++ b/config/mapping.json
@@ -16,6 +16,7 @@
   "ArrayProxy": ["@ember/array/proxy"],
   "Object": ["@ember/object"],
   "get": ["@ember/object", "get"],
+  "getWithDefault": ["@ember/object", "getWithDefault"],
   "set": ["@ember/object", "set"],
   "getProperties": ["@ember/object", "getProperties"],
   "setProperties": ["@ember/object", "setProperties"],

--- a/test/expected-output/getters.js
+++ b/test/expected-output/getters.js
@@ -1,0 +1,18 @@
+import {
+  computed,
+  get,
+  getWithDefault,
+  getProperties
+} from "@ember/object";
+import Component from "@ember/component";
+export default Component.extend({
+  someComputed: computed('a', 'b', 'c', 'd', function() {
+    const a = get(this, 'a');
+    const e = getProperties(this, 'a', 'b', 'c');
+    const f = get(get(this, 'd'), 'g');
+    const h = get(f, 'i');
+    const j = getProperties(h, 'k', 'l', 'm');
+
+    return a + getWithDefault(this, 'b', 'test');
+  }),
+});

--- a/test/expected-output/getters.js
+++ b/test/expected-output/getters.js
@@ -1,8 +1,8 @@
 import {
   computed,
   get,
-  getWithDefault,
-  getProperties
+  getProperties,
+  getWithDefault
 } from "@ember/object";
 import Component from "@ember/component";
 export default Component.extend({
@@ -12,6 +12,10 @@ export default Component.extend({
     const f = get(get(this, 'd'), 'g');
     const h = get(f, 'i');
     const j = getProperties(h, 'k', 'l', 'm');
+    const n = get(this, 'o');
+    const p = getProperties(this, 'q', 'r');
+    const s = getWithDefault(this, 't', 'u');
+    const v = get(h, 'w');
 
     return a + getWithDefault(this, 'b', 'test');
   }),

--- a/test/expected-output/getters.js
+++ b/test/expected-output/getters.js
@@ -1,10 +1,10 @@
-import {
-  computed,
-  get,
-  getProperties,
-  getWithDefault
-} from "@ember/object";
 import Component from "@ember/component";
+import {
+  get,
+  getWithDefault,
+  getProperties,
+  computed
+} from "@ember/object";
 export default Component.extend({
   someComputed: computed('a', 'b', 'c', 'd', function() {
     const a = get(this, 'a');

--- a/test/expected-output/setters.js
+++ b/test/expected-output/setters.js
@@ -1,5 +1,5 @@
-import { get, set, setProperties } from "@ember/object";
 import Component from "@ember/component";
+import { get, set, setProperties } from "@ember/object";
 export default Component.extend({
   someFunc(a) {
     set(this, 'fooProperty', 'bar');

--- a/test/expected-output/setters.js
+++ b/test/expected-output/setters.js
@@ -1,0 +1,11 @@
+import { get, set, setProperties } from "@ember/object";
+import Component from "@ember/component";
+export default Component.extend({
+  someFunc(a) {
+    set(this, 'fooProperty', 'bar');
+    setProperties(this, { foo: 'bar', baz: 'qux' });
+    set(a, 'fooProperty', 'bar');
+    setProperties(a, { foo: 'bar', baz: 'qux' });
+    set(get(this, 'b'), 'c', 'bar');
+  },
+});

--- a/test/input/getters.js
+++ b/test/input/getters.js
@@ -5,6 +5,10 @@ export default Ember.Component.extend({
     const f = this.get('d').get('g');
     const h = f.get('i');
     const j = h.getProperties('k', 'l', 'm');
+    const n = Ember.get(this, 'o');
+    const p = Ember.getProperties(this, 'q', 'r');
+    const s = Ember.getWithDefault(this, 't', 'u');
+    const v = Ember.get(h, 'w');
 
     return a + this.getWithDefault('b', 'test');
   }),

--- a/test/input/getters.js
+++ b/test/input/getters.js
@@ -1,0 +1,11 @@
+export default Ember.Component.extend({
+  someComputed: Ember.computed('a', 'b', 'c', 'd', function() {
+    const a = this.get('a');
+    const e = this.getProperties('a', 'b', 'c');
+    const f = this.get('d').get('g');
+    const h = f.get('i');
+    const j = h.getProperties('k', 'l', 'm');
+
+    return a + this.getWithDefault('b', 'test');
+  }),
+});

--- a/test/input/setters.js
+++ b/test/input/setters.js
@@ -1,0 +1,9 @@
+export default Ember.Component.extend({
+  someFunc(a) {
+    this.set('fooProperty', 'bar');
+    this.setProperties({ foo: 'bar', baz: 'qux' });
+    a.set('fooProperty', 'bar');
+    a.setProperties({ foo: 'bar', baz: 'qux' });
+    this.get('b').set('c', 'bar');
+  },
+});

--- a/transform.js
+++ b/transform.js
@@ -13,7 +13,7 @@ module.exports = transform;
  * It scans JavaScript files that use the Ember global and updates
  * them to use the module syntax from the proposed new RFC.
  */
-function transform(file, api, options) {
+function transform(file, api) {
   let source = file.source;
   let j = api.jscodeshift;
 
@@ -39,7 +39,15 @@ function transform(file, api, options) {
     // used as the root of a property lookup. If they match one of the provided
     // mappings, save it off for replacement later.
     let replacements = findUsageOfEmberGlobal(root)
-      .map(findReplacement(mappings));
+      .map(findReplacementAndCreateModules(mappings));
+
+    replaceIdentifiers(root, mappings, [
+      'get',
+      'getWithDefault',
+      'getProperties',
+      'set',
+      'setProperties',
+    ]);
 
     // Now that we've identified all of the replacements that we need to do, we'll
     // make sure to either add new `import` declarations, or update existing ones
@@ -103,12 +111,40 @@ function transform(file, api, options) {
     .paths();
   }
 
+  function findMemberExpression(root, identifierName) {
+    return root.find(j.CallExpression, {
+      callee: {
+        type: 'MemberExpression',
+        property: {
+          type: 'Identifier',
+          name: identifierName,
+        }
+      },
+    });
+  }
+
+  function createReplacement(mappings, propertyPath, nodePath) {
+    let mapping = mappings[propertyPath];
+
+    let mod = mapping.maybeCreateModule();
+    if (!mod.local) {
+      // Ember.computed.or => or
+      let local = propertyPath.split(".").slice(-1)[0];
+      if (includes(RESERVED, local)) {
+        local = `Ember${local}`;
+      }
+      mod.local = local;
+    }
+
+    return new Replacement(nodePath, mod);
+  }
+
   /**
    * Returns a function that can be used to map an array of MemberExpression
    * nodes into Replacement instances. Does the actual work of verifying if the
    * `Ember` identifier used in the MemberExpression is actually replaceable.
   */
-  function findReplacement(mappings) {
+  function findReplacementAndCreateModules(mappings) {
     return function(path) {
       // Expand the full set of property lookups. For example, we don't want
       // just "Ember.computed"—we want "Ember.computed.or" as well.
@@ -136,20 +172,34 @@ function transform(file, api, options) {
       }
 
       let [nodePath, propertyPath] = found;
-      let mapping = mappings[propertyPath];
-
-      let mod = mapping.getModule();
-      if (!mod.local) {
-        // Ember.computed.or => or
-        let local = propertyPath.split(".").slice(-1)[0];
-        if (includes(RESERVED, local)) {
-          local = `Ember${local}`;
-        }
-        mod.local = local;
-      }
-
-      return new Replacement(nodePath, mod);
+      return createReplacement(mappings, propertyPath, nodePath);
     };
+  }
+
+  function replaceIdentifiers(root, mappings, identifierNames)  {
+    let replacements = 0;
+    identifierNames.forEach((identifierName) => {
+      let nodes = findMemberExpression(root, identifierName);
+
+      if (nodes.size()) {
+        replacements += 1;
+        createReplacement(mappings, identifierName);
+
+        nodes.forEach(replaceExpression);
+      }
+    });
+
+    // recursively call in case of unusual but legal code that chains expressions
+    if (replacements > 0) {
+      replaceIdentifiers(root, mappings, identifierNames);
+    }
+  }
+
+  function replaceExpression(path) {
+    let args = [path.value.callee.object].concat(path.value.arguments);
+    let identifier = j.identifier(path.value.callee.property.name);
+    let callExpression = j.callExpression(identifier, args);
+    j(path).replaceWith(callExpression);
   }
 
   function extractSourceContext(path) {
@@ -413,7 +463,7 @@ class ModuleRegistry {
     return mod;
   }
 
-  get(source, imported, local) {
+  maybeCreate(source, imported, local) {
     let mod = this.find(source, imported, local);
     if (!mod) {
       mod = this.create(source, imported, local);
@@ -451,7 +501,7 @@ class Mapping {
     this.registry = registry;
   }
 
-  getModule() {
-    return this.registry.get(this.source, this.imported, this.local);
+  maybeCreateModule() {
+    return this.registry.maybeCreate(this.source, this.imported, this.local);
   }
 }

--- a/transform.js
+++ b/transform.js
@@ -41,14 +41,6 @@ function transform(file, api) {
     let replacements = findUsageOfEmberGlobal(root)
       .map(findReplacementAndCreateModules(mappings));
 
-    replaceIdentifiers(root, mappings, [
-      'get',
-      'getWithDefault',
-      'getProperties',
-      'set',
-      'setProperties',
-    ]);
-
     // Now that we've identified all of the replacements that we need to do, we'll
     // make sure to either add new `import` declarations, or update existing ones
     // to add new named exports or the default export.
@@ -57,6 +49,15 @@ function transform(file, api) {
     // Actually go through and replace each usage of `Ember.whatever` with the
     // imported binding (`whatever`).
     applyReplacements(replacements);
+
+    // Replace any getters or setters with imported version
+    replaceIdentifiers(root, mappings, [
+      'get',
+      'getWithDefault',
+      'getProperties',
+      'set',
+      'setProperties',
+    ]);
 
     // jscodeshift is not so great about giving us control over the resulting whitespace.
     // We'll use a regular expression to try to improve the situation (courtesy of @rwjblue).


### PR DESCRIPTION
Understand if this is outside the scope of this codemod. But to comply with this [eslint rule](https://github.com/netguru/eslint-plugin-ember/blob/master/docs/rules/use-ember-get-and-set.md) it felt close enough to update all things that "should be imported"