### PR TITLE
fix: assume global Ember is 'Ember'

### DIFF
--- a/transform.js
+++ b/transform.js
@@ -110,7 +110,7 @@ function transform(file, api, options) {
     let defaultImport = globalEmber.find(j.Identifier);
     let defaultMemberName = defaultImport.size() && defaultImport.get(0).node.name;
 
-    return defaultMemberName || null;
+    return defaultMemberName || "Ember";
   }
 
   /*


### PR DESCRIPTION
New test on master is failing because there is "no global Ember". Assumed it to be in the absence of a value, `Ember`