### PR TITLE
Handle destructured aliases

### DIFF
--- a/__testfixtures__/destructure-nested-namespace.input.js
+++ b/__testfixtures__/destructure-nested-namespace.input.js
@@ -1,0 +1,2 @@
+const { underscore } = Ember.String;
+underscore('hello-world');

--- a/__testfixtures__/destructure-nested-namespace.output.js
+++ b/__testfixtures__/destructure-nested-namespace.output.js
@@ -1,0 +1,2 @@
+import { underscore } from '@ember/string';
+underscore('hello-world');

--- a/__testfixtures__/final-boss.input.js
+++ b/__testfixtures__/final-boss.input.js
@@ -10,6 +10,9 @@
 //  * Variables named `Ember` are not considered
 //  * Manual aliasing (`var Component = Ember.Component` is removed)
 //  * `Ember` must be the root of property lookups (no `foo.Ember.bar`)
+//  * Deep destructured aliases are resolved (`String.underscore`)
+//  * Renamed destructured aliases are preserved (`get: myGet`)
+//  * Fully modularized destructuring statements are removed
 import FemberObject from "@ember/object";
 import { or as bore } from "@ember/object/computed";
 import Ember from 'ember';
@@ -18,13 +21,23 @@ let bar = foo.Ember.computed.or;
 
 const Component = Ember.Component;
 
+const {
+  get: myGet,
+  String: {
+    underscore
+  }
+} = Ember;
+
 export default Ember.Object.extend({
   postCountsPresent: Ember.computed.or('topic.unread', 'topic.displayNewPosts'),
   showBadges: Ember.computed.and('postBadgesEnabled', 'postCountsPresent')
 });
 
 export default Component.extend({
-  topicExists: Ember.computed.or('topic.foo', 'topic.bar')
+  topicExists: Ember.computed.or('topic.foo', 'topic.bar'),
+  topicSlug: Ember.computed(function() {
+    return underscore(myGet(this, 'topic.name'));
+  })
 });
 
 (function() {

--- a/__testfixtures__/final-boss.output.js
+++ b/__testfixtures__/final-boss.output.js
@@ -10,10 +10,17 @@
 //  * Variables named `Ember` are not considered
 //  * Manual aliasing (`var Component = Ember.Component` is removed)
 //  * `Ember` must be the root of property lookups (no `foo.Ember.bar`)
+//  * Deep destructured aliases are resolved (`String.underscore`)
+//  * Renamed destructured aliases are preserved (`get: myGet`)
+//  * Fully modularized destructuring statements are removed
 import EmberArray from '@ember/array';
 
+import { underscore } from '@ember/string';
 import Component from '@ember/component';
-import FemberObject, { computed } from "@ember/object";
+import FemberObject, {
+  get as myGet,
+  computed
+} from "@ember/object";
 import { or as bore, and } from "@ember/object/computed";
 
 let bar = foo.Ember.computed.or;
@@ -24,7 +31,10 @@ export default FemberObject.extend({
 });
 
 export default Component.extend({
-  topicExists: bore('topic.foo', 'topic.bar')
+  topicExists: bore('topic.foo', 'topic.bar'),
+  topicSlug: computed(function() {
+    return underscore(myGet(this, 'topic.name'));
+  })
 });
 
 (function() {

--- a/__testfixtures__/leave-destructured-name.input.js
+++ b/__testfixtures__/leave-destructured-name.input.js
@@ -1,0 +1,4 @@
+const { get: pleaseGet } = Ember;
+
+pleaseGet(x, y);
+Ember.get(x, y);

--- a/__testfixtures__/leave-destructured-name.output.js
+++ b/__testfixtures__/leave-destructured-name.output.js
@@ -1,0 +1,4 @@
+import { get as pleaseGet } from '@ember/object';
+
+pleaseGet(x, y);
+pleaseGet(x, y);

--- a/__testfixtures__/leave-unmatched-destructuring.input.js
+++ b/__testfixtures__/leave-unmatched-destructuring.input.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+const {
+  String: {
+    pluralize,
+    camelize
+  }
+} = Ember;
+
+pluralize('one');
+camelize('two');

--- a/__testfixtures__/leave-unmatched-destructuring.output.js
+++ b/__testfixtures__/leave-unmatched-destructuring.output.js
@@ -1,0 +1,11 @@
+import { camelize } from '@ember/string';
+import Ember from 'ember';
+
+const {
+  String: {
+    pluralize
+  }
+} = Ember;
+
+pluralize('one');
+camelize('two');


### PR DESCRIPTION
I've never been a huge fan of the `const { get } = Ember;` pattern, but nevertheless we have it a fair amount in our code. A [quick search on Ember Observer](https://emberobserver.com/code-search?codeQuery=%7D%20%3D%20Ember&sort=usages) confirms it's prevalent elsewhere, too.

Since #2 looks pretty stale (and doesn't handle nesting), I took a fresh pass at handling basic destructuring scenarios:

| Before | After |
| ---- | ---- |
| `let { get } = Ember` | `import { get } from '@ember/object'` | 
| `let { get: myGet } = Ember` | `import { get as myGet } from '@ember/object'` |
| `let { String: { underscore } } = Ember` | `import { underscore } from '@ember/string'` |
| `let { underscore } = Ember.String` | `import { underscore } from '@ember/string'` |

This version doesn't attempt to be _super_ intelligent, so patterns like this will be left untouched:
```js
const EmberString = Ember.String;
const { underscore } = EmberString;
```

Resolves #25 