### PR TITLE
Sort named imports

### DIFF
--- a/transform.js
+++ b/transform.js
@@ -482,12 +482,19 @@ function transform(file, api, options) {
         let result = importStatement.slice(0, openCurly + 1);
         let named = importStatement
               .slice(openCurly + 1, -6).split(',')
+              .sort()
               .map(name => `\n  ${name.trim()}`);
 
         return result + named.join(',') + '\n} from';
       } else {
-        // if the segment is < 50 chars just make sure it has proper spacing
-        return importStatement
+
+        let result = importStatement.slice(0, openCurly + 1);
+        let named = importStatement
+          .slice(openCurly + 1, -6).split(',').sort();
+
+        const sorted = result + named.join(',') + '\n} from';
+        // if the segment is < 50 chars sort and make sure it has proper spacing
+        return sorted
           .replace(/,\s*/g, ', ') // ensure there is a space after commas
           .replace(/\{\s*/, '{ ')
           .replace(/\s*\}/, ' }');


### PR DESCRIPTION
The named imports were originally in the order that they were used in the file. So one file would be
`import { get, set } ` and  another would be `import { set, get }`