### PR TITLE
Eol detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *   text eol=lf
+__testfixtures__/*.crlf.input.js   text eol=crlf
+__testfixtures__/*.crlf.output.js   text eol=crlf

--- a/__testfixtures__/leave-ember-test.crlf.input.js
+++ b/__testfixtures__/leave-ember-test.crlf.input.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  a: Ember.testing ? 1 : 2,
+});

--- a/__testfixtures__/leave-ember-test.crlf.output.js
+++ b/__testfixtures__/leave-ember-test.crlf.output.js
@@ -1,0 +1,6 @@
+import Component from '@ember/component';
+import Ember from 'ember';
+
+export default Component.extend({
+  a: Ember.testing ? 1 : 2,
+});

--- a/transform.js
+++ b/transform.js
@@ -7,8 +7,7 @@ const ERROR_WARNING = 1;
 const MISSING_GLOBAL_WARNING = 2;
 
 const OPTS = {
-  quote: 'single',
-  lineTerminator: '\n'
+  quote: 'single'
 };
 
 const EMBER_NAMESPACES = ['computed', 'inject'];
@@ -22,6 +21,9 @@ module.exports = transform;
  */
 function transform(file, api, options) {
   let source = file.source;
+
+  const lineTerminator = source.indexOf('\r\n') > -1 ? '\r\n' : '\n';
+
   let j = api.jscodeshift;
 
   let root = j(source);
@@ -95,7 +97,9 @@ function transform(file, api, options) {
 
     // jscodeshift is not so great about giving us control over the resulting whitespace.
     // We'll use a regular expression to try to improve the situation (courtesy of @rwjblue).
-    source = beautifyImports(root.toSource(OPTS));
+    source = beautifyImports(root.toSource(Object.assign({}, OPTS, {
+      lineTerminator: lineTerminator
+    })));
   } catch (e) {
     if (process.env.EMBER_MODULES_CODEMOD) {
       warnings.push([ERROR_WARNING, file.path, source, e.stack]);


### PR DESCRIPTION
fixes #44 

`eol` detection is extremely naive here. it just checks if the source file contains `\r\n`. If there are any better bullet proof solutions I'm open to improve here.
Hovewer I think even this dumb check makes things much better than it is now.

@XaserAcheron @rwjblue 