### PR TITLE
fixed mixed EOL in favor of cross platform

### DIFF
--- a/__tests__/bin-test.js
+++ b/__tests__/bin-test.js
@@ -145,7 +145,8 @@ describe('bin acceptance', function() {
           expect(stdout).toMatch('Done! Some files could not be upgraded automatically. See MODULE_REPORT.md.\n');
 
           let expectedOutput = fs.readFileSync(path.join(__dirname, 'expected', 'MODULE_REPORT.md'), 'utf8')
-            .replace(/\//, path.sep);
+            .replace(/\//, path.sep)
+            .replace(/\r?\n/g, require('os').EOL);
           let actualOutput = fs.readFileSync(path.join(tmpPath, 'MODULE_REPORT.md'), 'utf8');
 
           expect(actualOutput).toEqual(expectedOutput);

--- a/bin/ember-modules-codemod.js
+++ b/bin/ember-modules-codemod.js
@@ -99,7 +99,12 @@ function buildReport() {
         }
       });
 
-      fs.writeFileSync("MODULE_REPORT.md", "## Module Report\n" + report.join("\n"));
+      let file = "## Module Report\n" + report.join("\n");
+
+      // normalize line endings, so we don't end up with mixed
+      file = file.replace(/\r?\n/g, require('os').EOL);
+
+      fs.writeFileSync("MODULE_REPORT.md", file);
       console.log(chalk.yellow("\nDone! Some files could not be upgraded automatically. See " + chalk.blue("MODULE_REPORT.md") + "."));
     } else {
       console.log(chalk.green("\nDone! All uses of the Ember global have been updated."));


### PR DESCRIPTION
This will help test against fixture files with OS newlines. As seen in ember-cli-update tests:

```
      -  "MODULE_REPORT.md": "## Module Report\n### Unknown Global\n\n**Global**: `Ember.MODEL_FACTORY_INJECTIONS`\n\n**Location**: `app\\app.js` at line 8\n\n```js\nlet App;\r\n\r\nEmber.MODEL_FACTORY_INJECTIONS = true;\r\n\r\nApp = Ember.Application.extend({\r\n```\n"
      +  "MODULE_REPORT.md": "## Module Report\r\n### Unknown Global\r\n\r\n**Global**: `Ember.MODEL_FACTORY_INJECTIONS`\r\n\r\n**Location**: `app\\app.js` at line 8\r\n\r\n```js\r\nlet App;\r\n\r\nEmber.MODEL_FACTORY_INJECTIONS = true;\r\n\r\nApp = Ember.Application.extend({\r\n```\r\n"
```

There were a mix of different newlines in the file. Defaulting to OS newlines would help in this case when running on Windows.